### PR TITLE
Update links and company name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MB Design
 
-Enter a [MapBox map ID](https://www.mapbox.com/developers/api-overview/) or connect to a [TileMill](http://tilemill.com) or [TM2](http://github.com/mapbox/tm2) instance running on the same network as your iPhone and preview your map live, as you edit it, in a native iOS interface. 
+Enter a [Mapbox map ID](https://www.mapbox.com/developers/api/maps/#mapids) or connect to a [TileMill](https://www.mapbox.com/tilemill/) or [Mapbox Studio](https://github.com/mapbox/mapbox-studio) instance running on the same network as your iPhone and preview your map live, as you edit it, in a native iOS interface. 
 
 ![](screenshot.png)
 
 Possible setup required for TileMill: 
 
- * Add a line containing `"listenHost": "0.0.0.0",` to your `~/.tilemill/config.json` in order to share beyond your local machine. 
+ * Add a line containing `"listenHost": "0.0.0.0",` to your `~/.tilemill/config.json` in order to share beyond your local machine.


### PR DESCRIPTION
@incanus, I figure it’s more helpful to link directly to the section on map IDs rather than the guide’s front page.
